### PR TITLE
Control - Node: do not check for explicit subclasses, but executable classes

### DIFF
--- a/control.js
+++ b/control.js
@@ -14,9 +14,8 @@ class Control {
 	}
 
 	#register_one(node_cls) {
-		if(!Node.isPrototypeOf(node_cls)) {
-			throw new TypeError(`Only subclasses of Node are allowed, trying to add ${node_cls.name}`);
-		}
+		// Check if class is node and raise if needed
+		Node.isNode(node_cls, true);
 
 		const { TYPE } = node_cls;
 		if(!TYPE) {

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -122,6 +122,51 @@ class Node extends StateMachine {
 	post_run({ inputs, outputs, context } = {}) {
 		return true;
 	}
+
+	static isNode(cls, throws=false) {
+		// If we are in the same module and the cls extends ourselves
+		// we can be fairly certain that cls is a node
+		if(this.isPrototypeOf(cls)) {
+			return true;
+		}
+
+		// We need it to be a constructor
+		if(typeof cls !== 'function' || !cls.prototype) {
+			if(throws) {
+				throw new TypeError(`${cls.name} is not a valid node constructor: ${typeof cls}`);
+			}
+
+			return false;
+		}
+
+		// But if we require control-core twice, there will be two
+		// (maybe identical) Node classes in the wild. isPrototypeOf will
+		// not be enough
+
+		const required_methods = ['execute', 'run'];
+		for(const method of required_methods) {
+			if(!(method in cls.prototype)) {
+				if(throws) {
+					throw new Error(`${cls.name} is missing ${method} in its prototype`);
+				}
+
+				return false;
+			}
+
+			for(const prefix of ['pre', 'post']) {
+				const prefixed_method = `${prefix}_${method}`;
+				if(!(prefixed_method in cls.prototype)) {
+					if(throws) {
+						throw new Error(`${cls.name} is missing ${prefixed_method} in its prototype`);
+					}
+
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
 }
 
 class Edge {

--- a/test/control.js
+++ b/test/control.js
@@ -63,7 +63,7 @@ describe('Control', () => {
 			const TestControl = new Control();
 			expect(() => {
 				TestControl.register(NotANode);
-			}).to.throw(TypeError, 'Only subclasses');
+			}).to.throw(Error, 'missing');
 		});
 
 		it('Throws because of existing node Type', () => {

--- a/test/node.js
+++ b/test/node.js
@@ -25,6 +25,37 @@ describe('Node', () => {
 		})
 	});
 
+	describe('Prototype', () => {
+		it('Should recognize other nodes as not executable', () => {
+			const NotEither = 'plep';
+			class NotANode {};
+			class CloseNode {
+				run() {}
+				pre_run() {}
+				post_run() {}
+				execute() {}
+				pre_execute() {}
+			}
+
+			expect(() => Node.isNode(NotEither, true)).to.throw(TypeError);
+			expect(() => Node.isNode(NotANode, true)).to.throw(Error);
+			expect(() => Node.isNode(CloseNode, true)).to.throw(Error);
+		});
+
+		it('Should recognize other nodes as being executable', () => {
+			class Node2 {
+				run() {}
+				pre_run() {}
+				post_run() {}
+				execute() {}
+				pre_execute() {}
+				post_execute() {}
+			}
+
+			expect(Node.isNode(Node2)).to.be.true;
+		});
+	});
+
 	describe('Pre execution', () => {
 		it('Returns false and transitions to DID NOT RUN - Single value', () => {
 			const node = new TestNode({ id: 34 });


### PR DESCRIPTION


Removed isPrototypeOf because of module chain (multiple Cores can co-exist)